### PR TITLE
round() -> trunc() in Examples, fixed some models examples.

### DIFF
--- a/examples/audio/audio_music_stream.pas
+++ b/examples/audio/audio_music_stream.pas
@@ -42,7 +42,7 @@ begin
       ClearBackground(RAYWHITE);
       DrawText('MUSIC SHOULD BE PLAYING!', 255, 150, 20, LIGHTGRAY);
       DrawRectangle(200, 200, 400, 12, LIGHTGRAY);
-      DrawRectangle(200, 200, Round(timePlayed), 12, MAROON);
+      DrawRectangle(200, 200, Trunc(timePlayed), 12, MAROON);
       DrawRectangleLines(200, 200, 400, 12, GRAY);
       DrawText('PRESS SPACE TO RESTART MUSIC', 215, 250, 20, LIGHTGRAY);
       DrawText('PRESS P TO PAUSE/RESUME MUSIC', 208, 280, 20, LIGHTGRAY);

--- a/examples/core/core_2d_camera.pas
+++ b/examples/core/core_2d_camera.pas
@@ -82,8 +82,8 @@ begin
         DrawRectangle(-6000, 320, 13000, 8000, DARKGRAY);
         for i := 0 to MAX_BUILDINGS-1 do DrawRectangleRec(buildings[i], buildColors[i]);
         DrawRectangleRec(player, RED);
-        DrawRectangle(Round(camera.target.x), -500, 1, screenHeight*4, GREEN);
-        DrawRectangle(-500, Round(camera.target.y), screenWidth*4, 1, GREEN);
+        DrawRectangle(Trunc(camera.target.x), -500, 1, screenHeight*4, GREEN);
+        DrawRectangle(-500, Trunc(camera.target.y), screenWidth*4, 1, GREEN);
       EndMode2D;
 
       DrawText('SCREEN AREA', 640, 10, 20, RED);

--- a/examples/core/core_input_gamepad.pas
+++ b/examples/core/core_input_gamepad.pas
@@ -80,20 +80,20 @@ begin
                     // Draw axis: left joystick
                     DrawCircle(259, 152, 39, BLACK);
                     DrawCircle(259, 152, 34, LIGHTGRAY);
-                    DrawCircle(Round(259 + (GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_X)*20)),
-                               Round(152 - (GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_Y)*20)), 25, BLACK);
+                    DrawCircle(Trunc(259 + (GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_X)*20)),
+                               Trunc(152 - (GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_Y)*20)), 25, BLACK);
 
                     // Draw axis: right joystick
                     DrawCircle(461, 237, 38, BLACK);
                     DrawCircle(461, 237, 33, LIGHTGRAY);
-                    DrawCircle(Round(461 + (GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_X)*20)),
-                               Round(237 - (GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_Y)*20)), 25, BLACK);
+                    DrawCircle(Trunc(461 + (GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_X)*20)),
+                               Trunc(237 - (GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_Y)*20)), 25, BLACK);
 
                     // Draw axis: left-right triggers
                     DrawRectangle(170, 30, 15, 70, GRAY);
                     DrawRectangle(604, 30, 15, 70, GRAY);
-                    DrawRectangle(170, 30, 15, Round(((1.0 + GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_TRIGGER)) /2.0)*70), RED);
-                    DrawRectangle(604, 30, 15, Round(((1.0 + GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_TRIGGER)) /2.0)*70), RED);
+                    DrawRectangle(170, 30, 15, Trunc(((1.0 + GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_TRIGGER)) /2.0)*70), RED);
+                    DrawRectangle(604, 30, 15, Trunc(((1.0 + GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_TRIGGER)) /2.0)*70), RED);
 
                     //DrawText(Format('Xbox axis LT: %02.02f', [ GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_TRIGGER) ]) , 10, 40, 10, BLACK);
                     //DrawText(Format('Xbox axis RT: %02.02f', [ GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_TRIGGER) ]) , 10, 60, 10, BLACK);
@@ -128,20 +128,20 @@ begin
                     // Draw axis: left joystick
                     DrawCircle(319, 255, 35, BLACK);
                     DrawCircle(319, 255, 31, LIGHTGRAY);
-                    DrawCircle(319 + Round(GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_X)*20),
-                               255 + Round(GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_Y)*20), 25, BLACK);
+                    DrawCircle(319 + Trunc(GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_X)*20),
+                               255 + Trunc(GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_Y)*20), 25, BLACK);
 
                     // Draw axis: right joystick
                     DrawCircle(475, 255, 35, BLACK);
                     DrawCircle(475, 255, 31, LIGHTGRAY);
-                    DrawCircle(475 + Round(GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_X)*20),
-                               255 + Round(GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_Y)*20), 25, BLACK);
+                    DrawCircle(475 + Trunc(GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_X)*20),
+                               255 + Trunc(GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_Y)*20), 25, BLACK);
 
                     // Draw axis: left-right triggers
                     DrawRectangle(169, 48, 15, 70, GRAY);
                     DrawRectangle(611, 48, 15, 70, GRAY);
-                    DrawRectangle(169, 48, 15, Round(((1.0 - GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_TRIGGER)) /2.0)*70), RED);
-                    DrawRectangle(611, 48, 15, Round(((1.0 - GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_TRIGGER)) /2.0)*70), RED);
+                    DrawRectangle(169, 48, 15, Trunc(((1.0 - GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_LEFT_TRIGGER)) /2.0)*70), RED);
+                    DrawRectangle(611, 48, 15, Trunc(((1.0 - GetGamepadAxisMovement(GAMEPAD_PLAYER1, GAMEPAD_AXIS_RIGHT_TRIGGER)) /2.0)*70), RED);
                 end
                 else
                 begin

--- a/examples/models/models_billboard.pas
+++ b/examples/models/models_billboard.pas
@@ -34,7 +34,7 @@ begin
 
     while not WindowShouldClose() do
     begin
-      UpdateCamera(cam);
+      UpdateCamera(@cam);
       BeginDrawing();
       ClearBackground(RAYWHITE);
       BeginMode3d(cam);

--- a/examples/models/models_first_person_maze.pas
+++ b/examples/models/models_first_person_maze.pas
@@ -7,6 +7,7 @@ uses cmem, raylib, raymath, math;
 const
   screenWidth = 800;
   screenHeight = 450;
+
 var
   camera: TCamera;
   imMap: TImage;
@@ -27,8 +28,7 @@ begin
   InitWindow(screenWidth, screenHeight, 'raylib [models] example - first person maze');
 
   // Define the camera to look into our 3d world
-  //camera = { { 0.2f, 0.4f, 0.2f }, { 0.0f, 0.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }, 45.0f, 0 };
-  //camera := TCamera3DCreate( Vector3Create(0.2, 0.4, 0.2), Vector3Zero(), Vector3Create(0.0, 1.0, 0.0), 45.0, CAMERA_PERSPECTIVE);
+  // camera := TCamera3DCreate( Vector3Create(0.2, 0.4, 0.2), Vector3Zero(), Vector3Create(0.0, 1.0, 0.0), 45.0, CAMERA_PERSPECTIVE);
   camera.position := Vector3Create(0.2, 0.4, 0.2);
   camera.target := Vector3Zero();
   camera.up := Vector3Create(0.0, 1.0, 0.0);
@@ -41,9 +41,8 @@ begin
   model := LoadModelFromMesh(mesh);
 
   // NOTE: By default each cube is mapped to one part of texture atlas
-  texture := LoadTexture('res/textures/cubicmap_atlas.png');    // Load map texture
-  model.materials[0].maps[MAP_DIFFUSE].texture := texture;             // Set map diffuse texture
-  //SetMaterialTexture(@model.materials[0], MAP_DIFFUSE, texture);
+  texture := LoadTexture('res/textures/cubicmap_atlas.png');          // Load map texture
+  SetMaterialTexture(@model.materials[0], MAP_DIFFUSE, texture);      // Set map diffuse texture
 
   // Get map image data to be used for collision detection
   mapPixels := GetImageData(imMap);

--- a/examples/models/models_first_person_maze.pas
+++ b/examples/models/models_first_person_maze.pas
@@ -69,8 +69,8 @@ begin
       playerPos :=  Vector2Create(camera.position.x, camera.position.z );
       playerRadius := 0.1;  // Collision radius (player is modelled as a cilinder for collision)
 
-      playerCellX := Round(playerPos.x - mapPosition.x + 0.5);
-      playerCellY := Round(playerPos.y - mapPosition.z + 0.5);
+      playerCellX := Trunc(playerPos.x - mapPosition.x + 0.5);
+      playerCellY := Trunc(playerPos.y - mapPosition.z + 0.5);
 
       // Out-of-limits security check
       if (playerCellX < 0) then playerCellX := 0
@@ -87,7 +87,7 @@ begin
           begin
               if ((mapPixels[y*cubicmap.width + x].r = 255) and       // Collision: white pixel, only check R channel
                   (CheckCollisionCircleRec(playerPos, playerRadius,
-                  RectangleCreate(Round(mapPosition.x - 0.5 + x*1.0), Round(mapPosition.z - 0.5 + y*1.0), 1, 1 )))) then
+                  RectangleCreate(Trunc(mapPosition.x - 0.5 + x*1.0), Trunc(mapPosition.z - 0.5 + y*1.0), 1, 1 )))) then
               begin
                   // Collision detected, reset camera position
                   camera.position := oldCamPos;

--- a/examples/shapes/shapes_basic_shapes.pas
+++ b/examples/shapes/shapes_basic_shapes.pas
@@ -23,27 +23,27 @@ begin
 
         DrawText('some basic shapes available on raylib', 20, 20, 20, DARKGRAY);
 
-        DrawCircle(Round(screenWidth/4), 120, 35, DARKBLUE);
+        DrawCircle(Trunc(screenWidth/4), 120, 35, DARKBLUE);
 
-        DrawRectangle(Round(screenWidth/4*2) - 60, 100, 120, 60, RED);
-        DrawRectangleLines(Round(screenWidth/4*2) - 40, 320, 80, 60, ORANGE);  // NOTE: Uses QUADS internally, not lines
-        DrawRectangleGradientH(Round(screenWidth/4*2) - 90, 170, 180, 130, MAROON, GOLD);
+        DrawRectangle(Trunc(screenWidth/4*2) - 60, 100, 120, 60, RED);
+        DrawRectangleLines(Trunc(screenWidth/4*2) - 40, 320, 80, 60, ORANGE);  // NOTE: Uses QUADS internally, not lines
+        DrawRectangleGradientH(Trunc(screenWidth/4*2) - 90, 170, 180, 130, MAROON, GOLD);
 
-        DrawTriangle(Vector2Create(Round(screenWidth/4*3), 80),
-                     Vector2Create(Round(screenWidth/4*3) - 60, 150),
-                     Vector2Create(Round(screenWidth/4*3) + 60, 150), VIOLET);
+        DrawTriangle(Vector2Create(Trunc(screenWidth/4*3), 80),
+                     Vector2Create(Trunc(screenWidth/4*3) - 60, 150),
+                     Vector2Create(Trunc(screenWidth/4*3) + 60, 150), VIOLET);
 
-        DrawPoly(Vector2Create(Round(screenWidth/4*3), 320), 6, 80, 0, BROWN);
+        DrawPoly(Vector2Create(Trunc(screenWidth/4*3), 320), 6, 80, 0, BROWN);
 
-        DrawCircleGradient(Round(screenWidth/4), 220, 60, GREEN, SKYBLUE);
+        DrawCircleGradient(Trunc(screenWidth/4), 220, 60, GREEN, SKYBLUE);
 
         // NOTE: We draw all LINES based shapes together to optimize internal drawing,
         // this way, all LINES are rendered in a single draw pass
         DrawLine(18, 42, screenWidth - 18, 42, BLACK);
-        DrawCircleLines(Round(screenWidth/4), 340, 80, DARKBLUE);
-        DrawTriangleLines(Vector2Create(Round(screenWidth/4*3), 160),
-                          Vector2Create(Round(screenWidth/4*3) - 20, 230),
-                          Vector2Create(Round(screenWidth/4*3) + 20, 230), DARKBLUE);
+        DrawCircleLines(Trunc(screenWidth/4), 340, 80, DARKBLUE);
+        DrawTriangleLines(Vector2Create(Trunc(screenWidth/4*3), 160),
+                          Vector2Create(Trunc(screenWidth/4*3) - 20, 230),
+                          Vector2Create(Trunc(screenWidth/4*3) + 20, 230), DARKBLUE);
     EndDrawing();
   end;
   CloseWindow();        // Close window and OpenGL context

--- a/examples/textures/textures_particles_blending.pas
+++ b/examples/textures/textures_particles_blending.pas
@@ -87,9 +87,9 @@ begin
         begin
           if mouseTail[i].active then
             DrawTexturePro(smoke, RectangleCreate(0, 0, smoke.width, smoke.height),
-              RectangleCreate(Round(mouseTail[i].position.x),
-              Round(mouseTail[i].position.y), Round(smoke.width * mouseTail[i].size),
-              Round(smoke.height * mouseTail[i].size)),
+              RectangleCreate(Trunc(mouseTail[i].position.x),
+              Trunc(mouseTail[i].position.y), Trunc(smoke.width * mouseTail[i].size),
+              Trunc(smoke.height * mouseTail[i].size)),
               Vector2Create(smoke.width * mouseTail[i].size / 2,
               smoke.height * mouseTail[i].size / 2), mouseTail[i].rotation,
               Fade(mouseTail[i].color, mouseTail[i].alpha));


### PR DESCRIPTION
When I converted the c examples to pas I should have used `trunc()` and not `round()` so this is a attempt to fix that.

Note on my macos I can only use `SetMaterialTexture` if I [`{$PACKRECORDS C} TModel`](https://github.com/Morabaraba/raylib-pas/commit/54a1370e2ba51a46db4aea3437de0ed3b46dfc6f) but I don't want to merge that because not sure if it will work with delphi?

Thanks for fixing the 2d cam demo for 2.6-dev.

Note there still issues for example the models_billboard example is not transparent and the fps issue still linger but hopefully this weekend!

Later,