### PR TITLE
build.linux.sh can now build against libraylib.a WIP

### DIFF
--- a/build.linux.sh
+++ b/build.linux.sh
@@ -4,8 +4,17 @@ BIN=./bin
 TMP=./tmp
 RAYLIB=$BIN
 
+STATIC=true
+
 fpc -Fl$RAYLIB -Fl$LIBS -Fu$LIBS -FE$BIN -FU$TMP ./src/animation_test.pas
 for pasfile in ./examples/**/*.pas
 do
-  fpc -Fl$RAYLIB -Fl$LIBS -Fu$LIBS -FE$BIN -FU$TMP $pasfile
+  if [ $STATIC = true ]
+  then
+    # https://github.com/glfw/glfw/issues/1517
+    # $BIN must contain libglfw3.a and libraylib.a
+    fpc -k-lpthread -k-lm -k-lz -k-lGL -k-lX11 -k-lXext -k-lXfixes -k-ldl -Fu$BIN -Fl$LIBS -Fu$LIBS -FE$BIN -FU$TMP $pasfile
+  else
+    fpc -Fl$RAYLIB -Fl$LIBS -Fu$LIBS -FE$BIN -FU$TMP $pasfile
+  fi
 done


### PR DESCRIPTION
This is still WIP but I'm opening the request so long.

I would first like to fix the `Makefile` so that you can specify if it should statically link the examples.

But I want to share the current static link command.

Also can we maybe move `src/animation_test.pas` to `examples/models/models_animation.pas` to mimic the raylib examples?

Later,