### PR TITLE
compile a specific file eg, build.bat examples/core/core_2d_camera.pas

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,24 +1,28 @@
-SET debug=
-SET static=false
+IF EXIST "%1" (
+  fpc -Fl./libs -Fu./libs -FE./bin -FU./tmp -g -O1 %1
+) ELSE (
+  SET debug=
+  SET static=false
+  
+  FOR %%a in (%*) DO (
+    SET cmd=--debug
+    CALL SET arg=%%a:%cmd%=%%
+    IF NOT "x%%arg%%"=="x%%a%%" (
+      SET debug=-g -O1
+    )
+    SET cmd=--static
+    CALL SET arg=%%a:%cmd%=%%
+    IF NOT "x%%arg%%"=="x%%a%%" (
+      SET static=true
+    )
+  )
 
-FOR %%a in (%*) DO (
-  SET cmd=--debug
-  CALL SET arg=%%a:%cmd%=%%
-  IF NOT "x%%arg%%"=="x%%a%%" (
-    SET debug=-g -O1
+  FOR /R ./examples %%F IN (*.pas) DO (
+    IF "%static%"=="true" (
+      REM fpc -Fl./libs -Fu./libs -FE./bin -FU./tmp %debug% %%F
+    )
+    IF "%static%"=="false" (
+      fpc -Fl./libs -Fu./libs -FE./bin -FU./tmp %debug% %%F
+    )
   )
-  SET cmd=--static
-  CALL SET arg=%%a:%cmd%=%%
-  IF NOT "x%%arg%%"=="x%%a%%" (
-    SET static=true
-  )
-)
-
-FOR /R ./examples %%F IN (*.pas) DO (
-  if "%static%"=="true" (
-    REM fpc -Fl./libs -Fu./libs -FE./bin -FU./tmp %debug% %%F
-  )
-  if "%static%"=="false" (
-    fpc -Fl./libs -Fu./libs -FE./bin -FU./tmp %debug% %%F
-  )  
 )

--- a/build.linux.sh
+++ b/build.linux.sh
@@ -3,20 +3,25 @@ LIBS=./libs
 BIN=./bin
 TMP=./tmp
 RAYLIB=$BIN
+PASFILES=./examples/**/*.pas
+STATIC=false
+DEBUG=
 
-STATIC=false # SHARED by default
+if test -f "$1"; then
+    PASFILES=$1
+fi
+
 if [[ $@ == *'--static'* ]]
 then
   STATIC=true
 fi
 
-DEBUG=
 if [[ $@ == *'--debug'* ]]
 then
   DEBUG="-g -O1"
 fi
 
-for pasfile in ./examples/**/*.pas
+for pasfile in $PASFILES
 do
   if [ $STATIC = true ]
   then

--- a/build.macos.sh
+++ b/build.macos.sh
@@ -3,20 +3,25 @@ LIBS=./libs
 BIN=./bin
 TMP=./tmp
 RAYLIB=$BIN/libraylib.dylib
-
+PASFILES=./examples/**/*.pas
 STATIC=false
+DEBUG=
+
+if test -f "$1"; then
+    PASFILES=$1
+fi
+
 if [[ $@ == *'--static'* ]]
 then
   STATIC=true
 fi
 
-DEBUG=
 if [[ $@ == *'--debug'* ]]
 then
   DEBUG="-g -O1"
 fi
 
-for pasfile in ./examples/**/*.pas
+for pasfile in $PASFILES
 do
   if [ $STATIC = true ]
   then


### PR DESCRIPTION
I kind of broke all the `build.*` scripts because it now must compile all the examples.

In this commit you can specify to only compile a singe file eg

```sh
build.bat examples/core/core_2d_camera.pas
```

or

```sh
./build.macos.sh examples/core/core_2d_camera.pas --static --debug
```