### PR TITLE
Add Laz Package, Fix Font Struct/Record

### DIFF
--- a/libs/raylib.pas
+++ b/libs/raylib.pas
@@ -263,19 +263,19 @@ type
   PCharInfo = ^TCharInfo;
   TCharInfo = packed record
     value : Integer;
+    Rectangle: TRectangle;
     offsetX : Integer;
     offsetY : Integer;
     advanceX : Integer;
-    image : TImage;
+    data : Pointer;
   end;
 
   // Font type, includes texture and charSet array data
   PFont = ^TFont;
   TFont = packed record
+    texture : TTexture2D;
     baseSize : Integer;
     charsCount : Integer;
-    texture : TTexture2D;
-    recs : PRectangle;
     chars : PCharInfo;
   end;
 

--- a/pkg/raylib_pas.lpk
+++ b/pkg/raylib_pas.lpk
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <Package Version="4">
+    <PathDelim Value="\"/>
+    <Name Value="raylib_pas"/>
+    <Type Value="RunAndDesignTime"/>
+    <Author Value="Donald Duvall tazdij@github"/>
+    <CompilerOptions>
+      <Version Value="11"/>
+      <PathDelim Value="\"/>
+      <SearchPaths>
+        <OtherUnitFiles Value="..\libs"/>
+        <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)\"/>
+      </SearchPaths>
+    </CompilerOptions>
+    <Description Value="raylib binfing for pascal/fpc
+https://www.raylib.com/"/>
+    <Version Minor="1" Release="1" Build="1"/>
+    <Files Count="3">
+      <Item1>
+        <Filename Value="..\libs\raylib.pas"/>
+        <UnitName Value="raylib"/>
+      </Item1>
+      <Item2>
+        <Filename Value="..\libs\raymath.pas"/>
+        <UnitName Value="raymath"/>
+      </Item2>
+      <Item3>
+        <Filename Value="..\libs\rlgl.pas"/>
+        <UnitName Value="rlgl"/>
+      </Item3>
+    </Files>
+    <RequiredPkgs Count="1">
+      <Item1>
+        <PackageName Value="FCL"/>
+      </Item1>
+    </RequiredPkgs>
+    <UsageOptions>
+      <UnitPath Value="$(PkgOutDir)"/>
+    </UsageOptions>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+  </Package>
+</CONFIG>

--- a/pkg/raylib_pas.pas
+++ b/pkg/raylib_pas.pas
@@ -1,0 +1,21 @@
+{ This file was automatically created by Lazarus. Do not edit!
+  This source is only used to compile and install the package.
+ }
+
+unit raylib_pas;
+
+{$warn 5023 off : no warning about unused units}
+interface
+
+uses
+  raylib, raymath, rlgl, LazarusPackageIntf;
+
+implementation
+
+procedure Register;
+begin
+end;
+
+initialization
+  RegisterPackage('raylib_pas', @Register);
+end.


### PR DESCRIPTION
Added Lazarus package, now just just compile this package in Lazarus, then add it to any new project, it will that paths automatically 

Fixed Crash when drawing text with font, caused with wrong Font records.